### PR TITLE
feat(repo): add Docker Compose setup for local development (#2)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+**/.git/
+**/.vs/
+**/.idea/
+**/bin/
+**/obj/
+**/TestResults/
+**/*.user
+.env

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Copy this file to .env and fill in the values.
+# .env is excluded from version control.
+
+# PostgreSQL
+POSTGRES_DB=ingestor
+POSTGRES_USER=ingestor
+POSTGRES_PASSWORD=changeme
+
+# Connection string used by API and Worker
+# Host must match the service name in docker-compose.yml
+CONNECTION_STRING=Host=postgres;Port=5432;Database=ingestor;Username=ingestor;Password=changeme

--- a/.gitignore
+++ b/.gitignore
@@ -439,3 +439,6 @@ docs/api/swagger-ui/
 
 # Mermaid diagram outputs (generated)
 docs/assets/diagrams/*.svg
+
+# Local environment secrets – copy .env.example to .env and fill in values
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,47 @@
+services:
+  postgres:
+    image: postgres:17
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-ingestor}
+      POSTGRES_USER: ${POSTGRES_USER:-ingestor}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-ingestor} -d ${POSTGRES_DB:-ingestor}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  api:
+    build:
+      context: .
+      dockerfile: src/Ingestor.Api/Dockerfile
+    restart: unless-stopped
+    ports:
+      - "8200:8080"
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      ASPNETCORE_HTTP_PORTS: 8080
+      ConnectionStrings__DefaultConnection: ${CONNECTION_STRING:?CONNECTION_STRING is required}
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+  worker:
+    build:
+      context: .
+      dockerfile: src/Ingestor.Worker/Dockerfile
+    restart: unless-stopped
+    environment:
+      DOTNET_ENVIRONMENT: Development
+      ConnectionStrings__DefaultConnection: ${CONNECTION_STRING:?CONNECTION_STRING is required}
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+volumes:
+  postgres_data:

--- a/src/Ingestor.Api/Dockerfile
+++ b/src/Ingestor.Api/Dockerfile
@@ -1,0 +1,36 @@
+# Stage 1 – Build & Publish
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /source
+
+# Solution-level MSBuild defaults (global.json is intentionally excluded –
+# the SDK version is controlled by the image tag, not the local pin)
+COPY Directory.Build.props .
+
+# Project files + lock files first – restore layer is cached
+# until any .csproj or packages.lock.json changes
+COPY src/Ingestor.Domain/Ingestor.Domain.csproj            src/Ingestor.Domain/
+COPY src/Ingestor.Domain/packages.lock.json                src/Ingestor.Domain/
+COPY src/Ingestor.Application/Ingestor.Application.csproj  src/Ingestor.Application/
+COPY src/Ingestor.Application/packages.lock.json           src/Ingestor.Application/
+COPY src/Ingestor.Contracts/Ingestor.Contracts.csproj      src/Ingestor.Contracts/
+COPY src/Ingestor.Contracts/packages.lock.json             src/Ingestor.Contracts/
+COPY src/Ingestor.Infrastructure/Ingestor.Infrastructure.csproj src/Ingestor.Infrastructure/
+COPY src/Ingestor.Infrastructure/packages.lock.json        src/Ingestor.Infrastructure/
+COPY src/Ingestor.Api/Ingestor.Api.csproj                  src/Ingestor.Api/
+COPY src/Ingestor.Api/packages.lock.json                   src/Ingestor.Api/
+
+RUN dotnet restore src/Ingestor.Api/Ingestor.Api.csproj --locked-mode
+
+# Full source – copied after restore so the restore layer stays cached
+COPY src/ src/
+
+RUN dotnet publish src/Ingestor.Api/Ingestor.Api.csproj \
+    -c Release \
+    --no-restore \
+    -o /app/publish
+
+# Stage 2 – Runtime (ASP.NET Core, no SDK, no source code)
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
+WORKDIR /app
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "Ingestor.Api.dll"]

--- a/src/Ingestor.Worker/Dockerfile
+++ b/src/Ingestor.Worker/Dockerfile
@@ -1,0 +1,34 @@
+# Stage 1 – Build & Publish
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /source
+
+# Solution-level MSBuild defaults (global.json is intentionally excluded –
+# the SDK version is controlled by the image tag, not the local pin)
+COPY Directory.Build.props .
+
+# Project files + lock files first – restore layer is cached
+# until any .csproj or packages.lock.json changes
+COPY src/Ingestor.Domain/Ingestor.Domain.csproj            src/Ingestor.Domain/
+COPY src/Ingestor.Domain/packages.lock.json                src/Ingestor.Domain/
+COPY src/Ingestor.Application/Ingestor.Application.csproj  src/Ingestor.Application/
+COPY src/Ingestor.Application/packages.lock.json           src/Ingestor.Application/
+COPY src/Ingestor.Infrastructure/Ingestor.Infrastructure.csproj src/Ingestor.Infrastructure/
+COPY src/Ingestor.Infrastructure/packages.lock.json        src/Ingestor.Infrastructure/
+COPY src/Ingestor.Worker/Ingestor.Worker.csproj            src/Ingestor.Worker/
+COPY src/Ingestor.Worker/packages.lock.json                src/Ingestor.Worker/
+
+RUN dotnet restore src/Ingestor.Worker/Ingestor.Worker.csproj --locked-mode
+
+# Full source – copied after restore so the restore layer stays cached
+COPY src/ src/
+
+RUN dotnet publish src/Ingestor.Worker/Ingestor.Worker.csproj \
+    -c Release \
+    --no-restore \
+    -o /app/publish
+
+# Stage 2 – Runtime (.NET runtime only, no ASP.NET Core, no SDK, no source code)
+FROM mcr.microsoft.com/dotnet/runtime:10.0 AS runtime
+WORKDIR /app
+COPY --from=build /app/publish .
+ENTRYPOINT ["dotnet", "Ingestor.Worker.dll"]


### PR DESCRIPTION
  Add multi-stage Dockerfiles for API and Worker, docker-compose.yml
  with PostgreSQL, and .env.example for local secrets.

  - Dockerfile for Ingestor.Api (aspnet:10.0 runtime)
  - Dockerfile for Ingestor.Worker (runtime:10.0)
  - docker-compose.yml with postgres (health check), api, worker
  - .env.example as template for connection strings
  - .dockerignore to exclude bin/obj from build context
  - .env added to .gitignore