### PR TITLE
feat(application, domain, tests): add `RequeueImportJob` support for …

### DIFF
--- a/src/Ingestor.Api/Endpoints/ImportsEndpoints.cs
+++ b/src/Ingestor.Api/Endpoints/ImportsEndpoints.cs
@@ -1,6 +1,7 @@
 using Ingestor.Application.Common;
 using Ingestor.Application.Jobs.CreateImportJob;
 using Ingestor.Application.Jobs.GetImportJobById;
+using Ingestor.Application.Jobs.RequeueImportJob;
 using Ingestor.Application.Jobs.SearchImportJobs;
 using Ingestor.Contracts.V1.Responses;
 using Ingestor.Domain.Jobs;
@@ -26,6 +27,7 @@ public static class ImportsEndpoints
 
         group.MapGet("{id:guid}", GetImportJobByIdAsync);
         group.MapGet("", SearchImportJobsAsync);
+        group.MapPost("{id:guid}/requeue", RequeueImportJobAsync);
     }
 
     private static async Task<IResult> UploadImportAsync(
@@ -156,8 +158,26 @@ public static class ImportsEndpoints
             page.HasNextPage));
     }
 
+    private static async Task<IResult> RequeueImportJobAsync(
+        Guid id,
+        RequeueImportJobHandler handler,
+        CancellationToken ct)
+    {
+        var command = new RequeueImportJobCommand(new JobId(id));
+        var result = await handler.HandleAsync(command, ct);
+
+        if (result.IsFailure)
+            return MapError(result.Error!);
+
+        return Results.Accepted($"/api/imports/{id}");
+    }
+
     private static IResult MapError(ApplicationError error) => error.Type switch
     {
+        ErrorType.NotFound => Results.Problem(
+            statusCode: StatusCodes.Status404NotFound,
+            title: "Not found.",
+            detail: error.Message),
         ErrorType.Conflict => Results.Problem(
             statusCode: StatusCodes.Status409Conflict,
             title: "Conflict.",

--- a/src/Ingestor.Application/ApplicationServiceExtensions.cs
+++ b/src/Ingestor.Application/ApplicationServiceExtensions.cs
@@ -2,6 +2,7 @@ using Ingestor.Application.Abstractions;
 using Ingestor.Application.Common;
 using Ingestor.Application.Jobs.CreateImportJob;
 using Ingestor.Application.Jobs.GetImportJobById;
+using Ingestor.Application.Jobs.RequeueImportJob;
 using Ingestor.Application.Jobs.SearchImportJobs;
 using Ingestor.Application.Parsing;
 using Ingestor.Application.Pipeline;
@@ -19,6 +20,7 @@ public static class ApplicationServiceExtensions
         services.AddScoped<CreateImportJobHandler>();
         services.AddScoped<GetImportJobByIdHandler>();
         services.AddScoped<SearchImportJobsHandler>();
+        services.AddScoped<RequeueImportJobHandler>();
 
         services.AddScoped<ProcessDeliveryItemsHandler>();
         services.AddScoped<ImportPipelineHandler>();

--- a/src/Ingestor.Application/Jobs/RequeueImportJob/RequeueImportJobCommand.cs
+++ b/src/Ingestor.Application/Jobs/RequeueImportJob/RequeueImportJobCommand.cs
@@ -1,0 +1,5 @@
+using Ingestor.Domain.Jobs;
+
+namespace Ingestor.Application.Jobs.RequeueImportJob;
+
+public sealed record RequeueImportJobCommand(JobId Id);

--- a/src/Ingestor.Application/Jobs/RequeueImportJob/RequeueImportJobHandler.cs
+++ b/src/Ingestor.Application/Jobs/RequeueImportJob/RequeueImportJobHandler.cs
@@ -1,0 +1,46 @@
+using Ingestor.Application.Abstractions;
+using Ingestor.Application.Common;
+using Ingestor.Domain.Common;
+using Ingestor.Domain.Jobs;
+using Ingestor.Domain.Jobs.Enums;
+
+namespace Ingestor.Application.Jobs.RequeueImportJob;
+
+public sealed class RequeueImportJobHandler(
+    IImportJobRepository jobRepository,
+    IOutboxRepository outboxRepository,
+    IUnitOfWork unitOfWork,
+    IClock clock)
+{
+    private static readonly HashSet<JobStatus> _requeueableStatuses =
+    [
+        JobStatus.DeadLettered,
+        JobStatus.ValidationFailed
+    ];
+
+    public async Task<Result<RequeueImportJobResult>> HandleAsync(
+        RequeueImportJobCommand command, CancellationToken ct = default)
+    {
+        var job = await jobRepository.GetByIdAsync(command.Id, ct);
+
+        if (job is null)
+            return Result<RequeueImportJobResult>.NotFound(
+                "job.not_found",
+                $"Import job '{command.Id.Value}' was not found.");
+
+        if (!_requeueableStatuses.Contains(job.Status))
+            return Result<RequeueImportJobResult>.Conflict(
+                "job.not_requeueable",
+                $"Import job '{command.Id.Value}' cannot be requeued from status '{job.Status}'.");
+
+        var now = clock.UtcNow;
+
+        job.Requeue(now);
+
+        var outboxEntry = new OutboxEntry(OutboxEntryId.New(), job.Id, now);
+        await outboxRepository.AddAsync(outboxEntry, ct);
+        await unitOfWork.SaveChangesAsync(ct);
+
+        return Result<RequeueImportJobResult>.Success(new RequeueImportJobResult(job.Id.Value));
+    }
+}

--- a/src/Ingestor.Application/Jobs/RequeueImportJob/RequeueImportJobResult.cs
+++ b/src/Ingestor.Application/Jobs/RequeueImportJob/RequeueImportJobResult.cs
@@ -1,0 +1,3 @@
+namespace Ingestor.Application.Jobs.RequeueImportJob;
+
+public sealed record RequeueImportJobResult(Guid JobId);

--- a/src/Ingestor.Domain/Jobs/ImportJob.cs
+++ b/src/Ingestor.Domain/Jobs/ImportJob.cs
@@ -45,6 +45,18 @@ public sealed class ImportJob
         LastErrorMessage = errorMessage;
     }
 
+    public void Requeue(DateTimeOffset now)
+    {
+        ImportJobWorkflow.EnsureCanTransition(Status, JobStatus.Received);
+
+        CurrentAttempt = 0;
+        StartedAt = null;
+        CompletedAt = null;
+        LastErrorCode = null;
+        LastErrorMessage = null;
+        Status = JobStatus.Received;
+    }
+
     public void TransitionTo(JobStatus newStatus, DateTimeOffset now, int? processedItemCount = null)
     {
         ImportJobWorkflow.EnsureCanTransition(Status, newStatus);

--- a/src/Ingestor.Domain/Jobs/ImportJobWorkflow.cs
+++ b/src/Ingestor.Domain/Jobs/ImportJobWorkflow.cs
@@ -17,7 +17,8 @@ public static class ImportJobWorkflow
         (JobStatus.Processing,       JobStatus.ProcessingFailed),
         (JobStatus.ProcessingFailed, JobStatus.Parsing),
         (JobStatus.ProcessingFailed, JobStatus.DeadLettered),
-        (JobStatus.DeadLettered,     JobStatus.Received),
+        (JobStatus.DeadLettered,     JobStatus.Received),      // Manual requeue
+        (JobStatus.ValidationFailed, JobStatus.Received),      // Manual requeue after correction
     ];
 
     public static bool CanTransition(JobStatus from, JobStatus to)

--- a/tests/Ingestor.Tests.Unit/Jobs/RequeueImportJobTests.cs
+++ b/tests/Ingestor.Tests.Unit/Jobs/RequeueImportJobTests.cs
@@ -1,0 +1,107 @@
+using FluentAssertions;
+using Ingestor.Domain.Common;
+using Ingestor.Domain.Jobs;
+using Ingestor.Domain.Jobs.Enums;
+
+namespace Ingestor.Tests.Unit.Jobs;
+
+public sealed class RequeueImportJobTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 3, 17, 12, 0, 0, TimeSpan.Zero);
+
+    private static ImportJob CreateJobInStatus(JobStatus status)
+    {
+        var job = new ImportJob(
+            JobId.New(), "SUP-01", ImportType.CsvDeliveryAdvice,
+            "key", "ref", Now, maxAttempts: 3);
+
+        switch (status)
+        {
+            case JobStatus.ValidationFailed:
+                job.TransitionTo(JobStatus.Parsing, Now);
+                job.TransitionTo(JobStatus.ValidationFailed, Now);
+                break;
+            case JobStatus.DeadLettered:
+                job.TransitionTo(JobStatus.Parsing, Now);
+                job.TransitionTo(JobStatus.Validating, Now);
+                job.TransitionTo(JobStatus.Processing, Now);
+                job.TransitionTo(JobStatus.ProcessingFailed, Now);
+                job.RecordFailure("worker.transient_error", "timeout");
+                job.TransitionTo(JobStatus.DeadLettered, Now);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(status));
+        }
+
+        return job;
+    }
+
+    [Theory]
+    [InlineData(JobStatus.DeadLettered)]
+    [InlineData(JobStatus.ValidationFailed)]
+    public void Requeue_FromRequeueableStatus_SetsStatusToReceived(JobStatus from)
+    {
+        var job = CreateJobInStatus(from);
+
+        job.Requeue(Now);
+
+        job.Status.Should().Be(JobStatus.Received);
+    }
+
+    [Theory]
+    [InlineData(JobStatus.DeadLettered)]
+    [InlineData(JobStatus.ValidationFailed)]
+    public void Requeue_ResetsAttemptCountAndErrorFields(JobStatus from)
+    {
+        var job = CreateJobInStatus(from);
+
+        job.Requeue(Now);
+
+        job.CurrentAttempt.Should().Be(0);
+        job.LastErrorCode.Should().BeNull();
+        job.LastErrorMessage.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(JobStatus.DeadLettered)]
+    [InlineData(JobStatus.ValidationFailed)]
+    public void Requeue_ClearsTimestamps(JobStatus from)
+    {
+        var job = CreateJobInStatus(from);
+
+        job.Requeue(Now);
+
+        job.StartedAt.Should().BeNull();
+        job.CompletedAt.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(JobStatus.Received)]
+    [InlineData(JobStatus.Parsing)]
+    [InlineData(JobStatus.Succeeded)]
+    [InlineData(JobStatus.ProcessingFailed)]
+    public void Requeue_FromNonRequeueableStatus_ThrowsDomainException(JobStatus from)
+    {
+        var job = new ImportJob(
+            JobId.New(), "SUP-01", ImportType.CsvDeliveryAdvice,
+            "key", "ref", Now, maxAttempts: 3);
+
+        // Walk to the target status via valid path
+        var transitions = from switch
+        {
+            JobStatus.Received         => Array.Empty<JobStatus>(),
+            JobStatus.Parsing          => [JobStatus.Parsing],
+            JobStatus.Succeeded        => [JobStatus.Parsing, JobStatus.Validating, JobStatus.Processing, JobStatus.Succeeded],
+            JobStatus.ProcessingFailed => [JobStatus.Parsing, JobStatus.Validating, JobStatus.Processing, JobStatus.ProcessingFailed],
+            _ => throw new ArgumentOutOfRangeException(nameof(from))
+        };
+
+        foreach (var s in transitions)
+            job.TransitionTo(s, Now);
+
+        var act = () => job.Requeue(Now);
+
+        act.Should().Throw<DomainException>()
+            .Which.Error.Code.Should().Be("job.invalid_transition");
+    }
+}


### PR DESCRIPTION
…manual job reprocessing (#22)

- Introduce `RequeueImportJobHandler` for handling manual requeueing of dead-lettered and validation-failed jobs.
- Update `ImportJobWorkflow` to allow transitions from `DeadLettered` and `ValidationFailed` to `Received`.
- Add unit tests to validate requeue logic, including status changes, error resets, and timestamp clearing.
- Extend API with `POST /imports/{id}/requeue` endpoint to trigger requeue operations.
- Register `RequeueImportJobHandler` in DI container.